### PR TITLE
refactor(dictionary): return Optional values and simplify domain logic

### DIFF
--- a/app/api/routes/dictionary.py
+++ b/app/api/routes/dictionary.py
@@ -32,7 +32,7 @@ class DictionaryResponse(BaseModel):
 
 @router.post("")
 def add_entry(payload: DictionaryRequest):
-    dictionary.newentry(payload.word, payload.definition)
+    dictionary.add_entry(payload.word, payload.definition)
     return {"word": payload.word, "definition": payload.definition}
 
 
@@ -53,12 +53,12 @@ def add_entry(payload: DictionaryRequest):
     },
 )
 def get_entry(word: str):
-    result = dictionary.look(word)
+    result = dictionary.lookup(word)
 
-    if result.startswith("Can't find entry"):
+    if result is None:
         raise HTTPException(
             status_code=404,
-            detail=result
+            detail=f"Can't find entry for {word}"
         )
 
     return {"result": result}

--- a/app/dictionary/dictionary.py
+++ b/app/dictionary/dictionary.py
@@ -1,16 +1,14 @@
-from typing import Dict
-
-
+from typing import Dict, Optional
+ 
+ 
 class Dictionary:
     def __init__(self) -> None:
         self.entries: Dict[str, str] = {}
-
-    def newentry(self, word: str, definition: str) -> None:
+ 
+    def add_entry(self, word: str, definition: str) -> None:
         normalized_word = word.lower()
         self.entries[normalized_word] = definition
-
-    def look(self, word: str) -> str:
+ 
+    def lookup(self, word: str) -> Optional[str]:
         normalized_word = word.lower()
-        if normalized_word in self.entries:
-            return self.entries[normalized_word]
-        return f"Can't find entry for {word}"
+        return self.entries.get(normalized_word)

--- a/tests/unit/test_dictionary.py
+++ b/tests/unit/test_dictionary.py
@@ -3,32 +3,32 @@ from app.dictionary.dictionary import Dictionary
 
 def test_add_and_lookup_existing_word():
     d = Dictionary()
-    d.newentry("Apple", "A fruit that grows on trees")
+    d.add_entry("Apple", "A fruit that grows on trees")
 
-    result = d.look("Apple")
+    result = d.lookup("Apple")
     assert result == "A fruit that grows on trees"
 
 
 def test_lookup_non_existing_word():
     d = Dictionary()
 
-    result = d.look("Banana")
-    assert result == "Can't find entry for Banana"
+    result = d.lookup("Banana")
+    assert result is None
 
 
 def test_dictionary_overwrites_existing_entry():
     d = Dictionary()
-    d.newentry("Apple", "A fruit")
-    d.newentry("Apple", "A tech company")
+    d.add_entry("Apple", "A fruit")
+    d.add_entry("Apple", "A tech company")
 
-    result = d.look("Apple")
+    result = d.lookup("Apple")
     assert result == "A tech company"
 
 
 def test_dictionary_is_case_insensitive():
     d = Dictionary()
-    d.newentry("Apple", "a fruit")
+    d.add_entry("Apple", "a fruit")
 
-    assert d.look("apple") == "a fruit"
-    assert d.look("APPLE") == "a fruit"
-    assert d.look("ApPlE") == "a fruit"
+    assert d.lookup("apple") == "a fruit"
+    assert d.lookup("APPLE") == "a fruit"
+    assert d.lookup("ApPlE") == "a fruit"


### PR DESCRIPTION
The dictionary domain layer was refactored to return Optional[str] instead of error strings.
This improves separation of responsibilities, keeping error handling in the API layer and simplifying domain logic.