### PR TITLE
chore: make local coverage console-only and CI-driven

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,9 @@ security: security-bandit security-deps
 # Coverage (Optional)
 # =========================
 coverage:
-	$(DOCKER_COMPOSE) run --rm $(APP_SERVICE) pytest --cov=app
+	$(DOCKER_COMPOSE) run --rm \
+        -e COVERAGE_FILE=/tmp/.coverage \
+        $(APP_SERVICE) pytest --cov=app --cov-report=term
 
 # =========================
 # Terraform (Safe Operations Only)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Detailed pipeline documentation is available in the /docs directory.
 
 ---
 
+## Code Coverage
+
+Code coverage is generated during the CI pipeline using `pytest-cov` and
+published to SonarCloud for analysis.
+
+Coverage artifacts such as `coverage.xml` or `.coverage` are not committed
+to the repository.
+
+Local coverage execution (`make coverage`) is optional and intended only
+for quick developer feedback via console output.
+
+---
+
 ## Security
 
 Security checks are integrated directly into the CI pipeline:


### PR DESCRIPTION
Make local coverage console-only and CI-driven